### PR TITLE
Fix PageHeader.astro component not displaying custom avatars

### DIFF
--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -151,7 +151,7 @@ const sanitizedSubtitle: string = subtitle
       {
         author && (
           <div class="mt-6 flex items-center">
-            <Avatar title={author.name} image={author.image} subtitle={author.bio} />
+            <Avatar title={author.name} img={author.image} subtitle={author.bio} />
           </div>
         )
       }


### PR DESCRIPTION
The PageHeader component has a typo in its use of the Avatar component (should be `img` not `image`)

Currently all PageHeader components will use the default avatar, no matter what the author prop passes in, and this should fix that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal component property handling for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->